### PR TITLE
feat: add notes page with tag filtering

### DIFF
--- a/apps/promesa/src/app/app.component.html
+++ b/apps/promesa/src/app/app.component.html
@@ -1,2 +1,3 @@
-<app-nx-welcome></app-nx-welcome>
-<router-outlet></router-outlet>
+<tui-root>
+  <router-outlet></router-outlet>
+</tui-root>

--- a/apps/promesa/src/app/app.component.spec.ts
+++ b/apps/promesa/src/app/app.component.spec.ts
@@ -1,27 +1,24 @@
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
-import { NxWelcomeComponent } from './nx-welcome.component';
 import { RouterModule } from '@angular/router';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent, NxWelcomeComponent, RouterModule.forRoot([])],
+      imports: [AppComponent, RouterModule.forRoot([])],
     }).compileComponents();
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(
-      'Welcome promesa'
-    );
   });
 
   it(`should have as title 'promesa'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app.title).toEqual('promesa');
+  });
+
+  it('should render router outlet', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });

--- a/apps/promesa/src/app/app.component.ts
+++ b/apps/promesa/src/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { RouterModule } from '@angular/router';
-import { NxWelcomeComponent } from './nx-welcome.component';
+import { RouterOutlet } from '@angular/router';
+import { TuiRoot } from '@taiga-ui/core';
 
 @Component({
-  imports: [NxWelcomeComponent, RouterModule],
+  imports: [RouterOutlet, TuiRoot],
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrl: './app.component.less',

--- a/apps/promesa/src/app/app.routes.ts
+++ b/apps/promesa/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Route } from '@angular/router';
+import { NotesPageComponent } from './notes-page/notes-page.component';
 
-export const appRoutes: Route[] = [];
+export const appRoutes: Route[] = [
+  {
+    path: '',
+    component: NotesPageComponent,
+  },
+];

--- a/apps/promesa/src/app/notes-page/notes-page.component.html
+++ b/apps/promesa/src/app/notes-page/notes-page.component.html
@@ -1,0 +1,38 @@
+<div class="notes-container">
+  <aside class="tags">
+    <button
+      tuiTag
+      type="button"
+      *ngFor="let tag of tags"
+      (click)="selectTag(tag)"
+      [class.active]="selectedTag === tag"
+    >
+      {{ tag }}
+    </button>
+  </aside>
+  <section class="list">
+    <div class="filters">
+      <tui-input [(ngModel)]="titleFilter" placeholder="Поиск по заголовку"></tui-input>
+      <tui-input-date [(ngModel)]="dateFilter">Дата</tui-input-date>
+    </div>
+    <ul>
+      <li *ngFor="let note of filteredNotes">
+        <button
+          type="button"
+          (click)="selectNote(note)"
+          [class.active]="selectedNote === note"
+        >
+          <div class="note-title">{{ note.title }}</div>
+          <div class="note-date">{{ note.date | date: 'mediumDate' }}</div>
+        </button>
+      </li>
+    </ul>
+  </section>
+  <section class="editor" *ngIf="selectedNote">
+    <tui-input [(ngModel)]="selectedNote.title" placeholder="Заголовок"></tui-input>
+    <tui-textarea
+      class="content"
+      [(ngModel)]="selectedNote.content"
+    ></tui-textarea>
+  </section>
+</div>

--- a/apps/promesa/src/app/notes-page/notes-page.component.less
+++ b/apps/promesa/src/app/notes-page/notes-page.component.less
@@ -1,0 +1,81 @@
+.notes-container {
+  display: flex;
+  height: 100vh;
+}
+
+.tags {
+  width: 150px;
+  padding: 1rem;
+  background: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  button {
+    cursor: pointer;
+  }
+
+  .active {
+    background: #d1d1d1;
+  }
+}
+
+.list {
+  width: 250px;
+  border-right: 1px solid #ccc;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+
+  .filters {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
+    overflow-y: auto;
+
+    li {
+      button {
+        width: 100%;
+        padding: 0.5rem;
+        text-align: left;
+        border: none;
+        background: transparent;
+        cursor: pointer;
+        border-bottom: 1px solid #eee;
+
+        &.active {
+          background: #eaeaea;
+        }
+
+        .note-title {
+          font-weight: 600;
+        }
+
+        .note-date {
+          font-size: 0.8rem;
+          color: #666;
+        }
+      }
+    }
+  }
+}
+
+.editor {
+  flex: 1;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .content {
+    flex: 1;
+  }
+}

--- a/apps/promesa/src/app/notes-page/notes-page.component.ts
+++ b/apps/promesa/src/app/notes-page/notes-page.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TuiInputModule, TuiInputDateModule, TuiTagModule, TuiTextareaModule } from '@taiga-ui/kit';
+
+interface Note {
+  id: number;
+  title: string;
+  content: string;
+  tag: string;
+  date: Date;
+}
+
+@Component({
+  selector: 'app-notes-page',
+  imports: [
+    CommonModule,
+    FormsModule,
+    TuiInputModule,
+    TuiInputDateModule,
+    TuiTextareaModule,
+    TuiTagModule,
+    DatePipe,
+  ],
+  templateUrl: './notes-page.component.html',
+  styleUrl: './notes-page.component.less',
+})
+export class NotesPageComponent {
+  protected readonly tags: string[] = ['Работа', 'Личное', 'Идеи'];
+  protected selectedTag = this.tags[0];
+  protected titleFilter = '';
+  protected dateFilter: Date | null = null;
+
+  protected notes: Note[] = [
+    {
+      id: 1,
+      title: 'Первая заметка',
+      content: 'Содержимое первой заметки',
+      tag: 'Работа',
+      date: new Date(2024, 1, 10),
+    },
+    {
+      id: 2,
+      title: 'Список покупок',
+      content: 'Молоко, хлеб, масло',
+      tag: 'Личное',
+      date: new Date(2024, 2, 5),
+    },
+    {
+      id: 3,
+      title: 'Новая идея',
+      content: 'Нужно записать новую идею',
+      tag: 'Идеи',
+      date: new Date(2024, 5, 15),
+    },
+  ];
+
+  protected selectedNote: Note | null = this.notes[0];
+
+  protected get filteredNotes(): Note[] {
+    return this.notes.filter((note) => {
+      const matchesTag = !this.selectedTag || note.tag === this.selectedTag;
+      const matchesTitle =
+        !this.titleFilter ||
+        note.title.toLowerCase().includes(this.titleFilter.toLowerCase());
+      const matchesDate =
+        !this.dateFilter ||
+        note.date.toDateString() === this.dateFilter.toDateString();
+      return matchesTag && matchesTitle && matchesDate;
+    });
+  }
+
+  protected selectTag(tag: string): void {
+    this.selectedTag = tag;
+    this.selectedNote = null;
+  }
+
+  protected selectNote(note: Note): void {
+    this.selectedNote = note;
+  }
+}
+

--- a/apps/promesa/src/styles.less
+++ b/apps/promesa/src/styles.less
@@ -1,1 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
+@import '@taiga-ui/core/styles/taiga-ui-global';
+@import '@taiga-ui/kit/styles/taiga-ui-kit';

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "@angular/platform-browser": "~19.2.0",
     "@angular/platform-browser-dynamic": "~19.2.0",
     "@angular/router": "~19.2.0",
+    "@angular/cdk": "~19.2.0",
+    "@taiga-ui/core": "^4.0.0",
+    "@taiga-ui/kit": "^4.0.0",
     "rxjs": "~7.8.0",
     "zone.js": "~0.15.0"
   },


### PR DESCRIPTION
## Summary
- add notes page with tag sidebar, title/date filters, and editor
- integrate Taiga UI root and styles
- add dependencies for Taiga UI and Angular CDK

## Testing
- `npx nx lint promesa`
- `npx nx test promesa` *(fails: Cannot find module '@taiga-ui/core')*

------
https://chatgpt.com/codex/tasks/task_e_689dec4e13c0832082d5fd8d553612ec