### PR TITLE
refactor: replace deprecated tui components

### DIFF
--- a/apps/promesa/src/app/notes-page/notes-page.component.html
+++ b/apps/promesa/src/app/notes-page/notes-page.component.html
@@ -18,7 +18,7 @@
         formControlName="title"
         placeholder="Поиск по заголовку"
       />
-      <tui-input-date formControlName="date">Дата</tui-input-date>
+      <input tuiInputDate type="date" formControlName="date" />
     </div>
     <ul>
       <li *ngFor="let note of filteredNotes">
@@ -35,6 +35,6 @@
   </section>
   <section class="editor" *ngIf="selectedNote" [formGroup]="noteForm">
     <input tuiTextfield formControlName="title" placeholder="Заголовок" />
-    <tui-textarea class="content" formControlName="content"></tui-textarea>
+    <textarea tuiTextarea class="content" formControlName="content"></textarea>
   </section>
 </div>

--- a/apps/promesa/src/app/notes-page/notes-page.component.ts
+++ b/apps/promesa/src/app/notes-page/notes-page.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TuiInputDate, TuiTag, TuiTextarea } from '@taiga-ui/kit';
 import { TuiTextfieldControllerModule, TuiTextfield } from '@taiga-ui/core';
+import { TuiDay } from '@taiga-ui/cdk';
 import { CdkDragDrop, DragDropModule, moveItemInArray } from '@angular/cdk/drag-drop';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -20,8 +21,8 @@ interface Note {
     CommonModule,
     ReactiveFormsModule,
     TuiInputDate,
-    TuiTextarea,
     TuiTag,
+    TuiTextarea,
     TuiTextfield,
     TuiTextfieldControllerModule,
     DragDropModule,
@@ -36,7 +37,7 @@ export class NotesPageComponent {
 
   protected readonly filtersForm = new FormGroup({
     title: new FormControl('', { nonNullable: true }),
-    date: new FormControl<Date | null>(null),
+    date: new FormControl<TuiDay | null>(null),
   });
 
   protected readonly noteForm = new FormGroup({
@@ -87,14 +88,18 @@ export class NotesPageComponent {
   }
 
   protected get filteredNotes(): Note[] {
-    const { title, date } = this.filtersForm.value;
+    const { title, date } = this.filtersForm.value as {
+      title: string;
+      date: TuiDay | null;
+    };
 
     return this.notes.filter((note) => {
       const matchesTag = !this.selectedTag || note.tag === this.selectedTag;
       const matchesTitle =
         !title || note.title.toLowerCase().includes(title.toLowerCase());
       const matchesDate =
-        !date || note.date.toDateString() === date.toDateString();
+        !date ||
+        note.date.toDateString() === date.toLocalNativeDate().toDateString();
       return matchesTag && matchesTitle && matchesDate;
     });
   }


### PR DESCRIPTION
## Summary
- replace tui-input-date and tui-textarea tags with directive-based alternatives
- adjust filter form to handle TuiDay values

## Testing
- `npx nx test promesa`

------
https://chatgpt.com/codex/tasks/task_e_689dfe4c5428832090be988caa3d9f5c