### PR TITLE
feat: add todo edit component

### DIFF
--- a/apps/promesa/src/app/app.routes.ts
+++ b/apps/promesa/src/app/app.routes.ts
@@ -1,3 +1,9 @@
 import { Route } from '@angular/router';
 
-export const appRoutes: Route[] = [];
+export const appRoutes: Route[] = [
+  {
+    path: 'todo/:id',
+    loadComponent: () =>
+      import('./todo-edit.component').then((m) => m.TodoEditComponent),
+  },
+];

--- a/apps/promesa/src/app/todo-edit.component.ts
+++ b/apps/promesa/src/app/todo-edit.component.ts
@@ -1,0 +1,33 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+
+@Component({
+  selector: 'app-todo-edit',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  template: `
+    <h2>Edit note {{ id }}</h2>
+    <form [formGroup]="form" (ngSubmit)="save()">
+      <label for="note">Note</label>
+      <input id="note" type="text" formControlName="note" />
+      <button type="submit">Save</button>
+    </form>
+  `,
+})
+export class TodoEditComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly route = inject(ActivatedRoute);
+
+  readonly id = this.route.snapshot.paramMap.get('id');
+  readonly form = this.fb.group({
+    note: [''],
+  });
+
+  save() {
+    if (this.form.valid) {
+      console.log(`Saving note ${this.id}:`, this.form.value.note);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add TodoEditComponent with a simple form
- wire component to new todo/:id route

## Testing
- `CI=true npx nx test promesa --skip-nx-cache`
- `CI=true npx nx lint promesa --no-warnings`


------
https://chatgpt.com/codex/tasks/task_e_689e0631028883209d07f6a945ea8ed6